### PR TITLE
MenuItemsで動的生成していたgroupクラスをpeerクラスに変更

### DIFF
--- a/app/components/navbar/MenuItems.tsx
+++ b/app/components/navbar/MenuItems.tsx
@@ -53,17 +53,19 @@ const MenuItems: React.FC<MenuItemsProps> = ({
                                 // サブメニューが存在する場合、アイテムhover時にSubMenuItemsを表示
                                 // 存在しない場合、アイテムにリンクを設定
                                 item.submenu.length > 0 ? (
-                                    <div
-                                        className={`
-                                            group/${item.group}
-                                            px-4 py-[30px]
-                                        `}
-                                    >
-                                        <Link className="hover:text-[#121212]" href="">
-                                            {item.title}
-                                        </Link>
+                                    <div>
                                         <div
-                                            className={`
+                                            className="
+                                                peer
+                                                px-4 py-[30px]
+                                            "
+                                        >
+                                            <Link className="hover:text-[#121212]" href="">
+                                                {item.title}
+                                            </Link>
+                                        </div>
+                                        <div
+                                            className="
                                                 hidden 
                                                 px-12 
                                                 w-full 
@@ -72,8 +74,9 @@ const MenuItems: React.FC<MenuItemsProps> = ({
                                                 top-20 
                                                 left-0 
                                                 bg-white 
-                                                group-hover/${item.group}:block 
-                                            `}
+                                                peer-hover/:block 
+                                                hover:block
+                                            "
                                         >
                                             <SubMenuItems
                                                 subMenu={item.submenu}


### PR DESCRIPTION
### Issue
#25 

### 内容
Tailwind CSSでは動的生成したクラス名をサポートしていないため以下を修正
1. 動的生成していたgroupクラスをpeerクラスに変更
2. 子要素だったサブメニューを兄弟要素に変更

### 確認手順
1. メニューにカーソルをあてたときにサブメニューが表示される。